### PR TITLE
working on the update views Startup functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=
 NEXT_PUBLIC_SANITY_DATASET="production"
 NEXT_PUBLIC_SANITY_API_VERSION="vX" // latest version
 
+SANITY_WRITE_TOKEN= // allows us to create and update Startup
+
 ```
 
 PS: Some env variables will be added later 😉.

--- a/components/templates/StartupCollectionsTemp/StartupCollectionsTemp.tsx
+++ b/components/templates/StartupCollectionsTemp/StartupCollectionsTemp.tsx
@@ -23,7 +23,7 @@ const StartupCollectionsTemp: React.FC<StartupCollectionsTempProps> = async ({
   };
 
   return (
-    <section className={`${className || ''}`}>
+    <section className={`py-8 md:mx-4 xl:m-auto ${className || ''}`}>
       <h3 className="my-5 font-bold text-[32px]">
         {query ? `Search results for "${query}"` : 'All Startups'}
       </h3>

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   experimental: {
     ppr: 'incremental',
+    after: true,
   },
   images: {
     remotePatterns: [

--- a/sanity/env.ts
+++ b/sanity/env.ts
@@ -1,20 +1,22 @@
 export const apiVersion =
-  process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2024-11-04'
+  process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2024-11-04';
 
 export const dataset = assertValue(
   process.env.NEXT_PUBLIC_SANITY_DATASET,
-  'Missing environment variable: NEXT_PUBLIC_SANITY_DATASET'
-)
+  'Missing environment variable: NEXT_PUBLIC_SANITY_DATASET',
+);
 
 export const projectId = assertValue(
   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
-  'Missing environment variable: NEXT_PUBLIC_SANITY_PROJECT_ID'
-)
+  'Missing environment variable: NEXT_PUBLIC_SANITY_PROJECT_ID',
+);
+
+export const token = process.env.SANITY_WRITE_TOKEN;
 
 function assertValue<T>(v: T | undefined, errorMessage: string): T {
   if (v === undefined) {
-    throw new Error(errorMessage)
+    throw new Error(errorMessage);
   }
 
-  return v
+  return v;
 }

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -1,10 +1,10 @@
-import { createClient } from 'next-sanity'
+import { createClient } from 'next-sanity';
 
-import { apiVersion, dataset, projectId } from '../env'
+import { apiVersion, dataset, projectId } from '../env';
 
 export const client = createClient({
   projectId,
   dataset,
   apiVersion,
   useCdn: true, // Set to false if statically generating pages, using ISR or tag-based revalidation
-})
+});

--- a/sanity/lib/write-client.ts
+++ b/sanity/lib/write-client.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import { createClient } from 'next-sanity';
+
+import { apiVersion, dataset, projectId, token } from '../env';
+
+export const writeClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  token,
+  useCdn: true,
+});
+
+if (!writeClient.config().token) {
+  throw new Error('💥 No provided token 💥');
+}


### PR DESCRIPTION
- setting up write-client with token (Sanity)
- usage "unstable_after" that will update the StartupViews in background without blocking the UI
