### PR TITLE
working on Playlist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A project that allows Entrepreneurs to introduce and pitch their Startups and co
 
 ## Getting started
 
+#### 1) YC Directory app
+
 When developing this project, I used `pnpm` as a package manager and re-created the project with my coding style, but some assets and code snippets were picked from the original repository that we can find [here](https://github.com/adrianhajdin/yc_directory).
 
 - pnpm installation:
@@ -17,7 +19,7 @@ When developing this project, I used `pnpm` as a package manager and re-created 
 npm install -g pnpm
 ```
 
-### 1 - Local development:
+##### 1 - Local development:
 
 - We can clone the project by following this command:
 
@@ -53,7 +55,7 @@ pnpm storybook
 
 We can see the project stories on the browser at [http://localhost:6006/](http://localhost:6006/)
 
-### 2 - Env variables:
+##### 2 - Env variables:
 
 Please, create file `.env.local` inside the project root directory, then add:
 
@@ -75,6 +77,34 @@ SANITY_SECRET_TOKEN= // allows us to create and update Startup
 ```
 
 PS: Some env variables will be added later 😉.
+
+#### B) Sanity - YC Directory
+
+##### 1 - Sanity Typegen
+
+May be in the future, we want to add another data(ex: reviews, ...), and to generate types for those schemas, please use this guide bellow:
+
+- First, we need to extract our new schema
+
+```bash
+pnpm sanity:extract
+
+// after running this command, we get a message like this:
+// ✅ Extracted schema to D:\projects\yc-directory\project\schema.json
+
+```
+
+- Then, we can generate and get an updated typegen from those schema
+
+```bash
+pnpm sanity:typegen
+
+after running this command, we get a message like this:
+// ✅ Generated TypeScript types for 15 schema types and 0 GROQ queries in 0 files into: ./sanity/types.ts
+
+```
+
+For more information about `Sanity typegen`, we can check the official docs at this [link](https://www.sanity.io/docs/sanity-typegen).
 
 ## Authentication with Next Auth
 

--- a/app/(overview)/startups/[slug]/page.tsx
+++ b/app/(overview)/startups/[slug]/page.tsx
@@ -13,7 +13,11 @@ import { STARTUP_DETAIL_QUERY } from '@project/sanity/queries';
 import { formattedDate } from '@project/utils/app';
 import { StartupItemType } from '@project/utils/types';
 
-import { HeroPlaceholderType, HeroTemp } from '@project/components/templates';
+import {
+  HeroPlaceholderType,
+  HeroTemp,
+  PlaylistStartupCollectionsTemp,
+} from '@project/components/templates';
 import { Skeleton } from '@project/components/atoms';
 import { StartupView } from '@project/components/molecules';
 
@@ -98,6 +102,14 @@ export default async function page({
           )}
         </div>
       </section>
+
+      {/* EDITOR PICKS */}
+      <Suspense fallback={<p>Loading Editor picks...</p>}>
+        <PlaylistStartupCollectionsTemp
+          className="px-6 py-10 max-w-screen-lg mx-auto"
+          slug="editor-picks"
+        />
+      </Suspense>
 
       <Suspense fallback={<Skeleton className="view_skeleton" />}>
         <StartupView id={startup._id} />

--- a/components/templates/PlaylistStartupCollectionsTemp/PlaylistStartupCollectionsTemp.tsx
+++ b/components/templates/PlaylistStartupCollectionsTemp/PlaylistStartupCollectionsTemp.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { client } from '@project/sanity/lib/client';
+import { EDITOR_PICKS_PLAYLISTS_QUERY } from '@project/sanity/queries';
+
+import { PlaylistCollectionsTypes } from '@project/utils/types';
+
+import { StartupLists } from '@project/components/orgnisms';
+
+export type PlaylistStartupCollectionsTempProps = {
+  className?: string;
+  slug: string;
+};
+
+const PlaylistStartupCollectionsTemp: React.FC<
+  PlaylistStartupCollectionsTempProps
+> = async ({ className, slug }) => {
+  const data = await client
+    .withConfig({ useCdn: false })
+    .fetch<PlaylistCollectionsTypes>(EDITOR_PICKS_PLAYLISTS_QUERY, { slug });
+
+  if (!data) {
+    return (
+      <section className={`py-8 md:mx-4 xl:m-auto ${className || ''}`}>
+        <p className="font-semibold text-center">
+          There is no selection yet. Be the first Startup on the selection 😃.
+        </p>
+      </section>
+    );
+  }
+
+  const { title, selection } = data;
+
+  return (
+    <section className={`py-8 md:mx-4 xl:m-auto ${className || ''}`}>
+      <h3 className="my-5 font-bold text-[32px]">
+        {title || 'Our best Startup selection 😃'}
+      </h3>
+
+      <StartupLists data={selection} />
+    </section>
+  );
+};
+
+export default PlaylistStartupCollectionsTemp;

--- a/components/templates/index.ts
+++ b/components/templates/index.ts
@@ -5,3 +5,4 @@ export { default as HeroTemp } from './HeroTemp/HeroTemp';
 
 export { default as StartupCollectionsLiveApiTemp } from './StartupCollectionsLiveApiTemp/StartupCollectionsLiveApiTemp';
 export { default as AuthorStartupCollectionsTemp } from './AuthorStartupCollectionsTemp/AuthorStartupCollectionsTemp';
+export { default as PlaylistStartupCollectionsTemp } from './PlaylistStartupCollectionsTemp/PlaylistStartupCollectionsTemp';

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch:storybook": "storybook dev -p 6006",
     "storybook": "concurrently pnpm:watch:*",
     "build-storybook": "pnpm build:tailwind && storybook build",
+    "sanity:extract": "npx sanity schema extract",
     "sanity:typegen": "npx sanity@latest typegen generate",
     "next:canary": "pnpm add next@canary"
   },

--- a/sanity/queries/index.ts
+++ b/sanity/queries/index.ts
@@ -1,2 +1,3 @@
 export * from './author.query';
 export * from './startup.query';
+export * from './playlist.query';

--- a/sanity/queries/playlist.query.ts
+++ b/sanity/queries/playlist.query.ts
@@ -1,0 +1,22 @@
+import { defineQuery } from 'next-sanity';
+
+export const EDITOR_PICKS_PLAYLISTS_QUERY = defineQuery(`
+*[_type == "playlist" && defined(slug.current) && slug.current == $slug] | order(_createdAt desc) {
+  _id,
+  title,
+  slug,
+  selection[] -> {
+    _id,
+    title,
+    pitch,
+    description,
+    image,
+    views,
+    category,
+    author -> {_id, username, bio, email, image, slug},
+    slug,
+    _createdAt
+  },
+    _createdAt
+}[0]
+  `);

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,7 +2,8 @@ import { type SchemaTypeDefinition } from 'sanity';
 
 import { authorSchema } from './author.schema';
 import { startupSchema } from './startup.schema';
+import { playlistSchema } from './playlist.schema';
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [authorSchema, startupSchema],
+  types: [authorSchema, startupSchema, playlistSchema],
 };

--- a/sanity/schemaTypes/playlist.schema.ts
+++ b/sanity/schemaTypes/playlist.schema.ts
@@ -1,0 +1,27 @@
+import { defineField, defineType } from 'sanity';
+
+// eg: Editor picks, Top 10 Startups of the year, ...
+
+export const playlistSchema = defineType({
+  name: 'playlist',
+  title: 'Playlist',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      validation: (Rule) =>
+        Rule.required().error("Please, enter your Playlist's name 😃."),
+    }),
+    defineField({
+      name: 'selection',
+      type: 'array',
+      of: [{ type: 'reference', to: { type: 'startup' } }],
+    }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      options: { source: 'title' },
+    }),
+  ],
+});

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -7,4 +7,5 @@ export const structure: StructureResolver = (S) =>
     .items([
       S.documentTypeListItem('author').title('Authors'),
       S.documentTypeListItem('startup').title('Startups'),
+      S.documentTypeListItem('playlist').title('Playlists'),
     ]);

--- a/sanity/types.ts
+++ b/sanity/types.ts
@@ -125,6 +125,23 @@ export type SanityAssetSourceData = {
   url?: string;
 };
 
+export type Playlist = {
+  _id: string;
+  _type: 'playlist';
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  selection?: Array<{
+    _ref: string;
+    _type: 'reference';
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: 'startup';
+  }>;
+  slug?: Slug;
+};
+
 export type Startup = {
   _id: string;
   _type: 'startup';
@@ -146,12 +163,6 @@ export type Startup = {
   slug?: Slug;
 };
 
-export type Slug = {
-  _type: 'slug';
-  current?: string;
-  source?: string;
-};
-
 export type Author = {
   _id: string;
   _type: 'author';
@@ -163,6 +174,12 @@ export type Author = {
   email?: string;
   image?: string;
   slug?: Slug;
+};
+
+export type Slug = {
+  _type: 'slug';
+  current?: string;
+  source?: string;
 };
 
 export type Markdown = string;
@@ -178,8 +195,9 @@ export type AllSanitySchemaTypes =
   | SanityImageMetadata
   | Geopoint
   | SanityAssetSourceData
+  | Playlist
   | Startup
-  | Slug
   | Author
+  | Slug
   | Markdown;
 export declare const internalGroqTypeReferenceTo: unique symbol;

--- a/schema.json
+++ b/schema.json
@@ -663,6 +663,102 @@
     }
   },
   {
+    "name": "playlist",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "playlist"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "selection": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "startup",
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "startup",
     "type": "document",
     "attributes": {
@@ -780,36 +876,6 @@
     }
   },
   {
-    "name": "slug",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "slug"
-          }
-        },
-        "current": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
     "name": "author",
     "type": "document",
     "attributes": {
@@ -871,6 +937,44 @@
           "type": "string"
         },
         "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        },
+        "current": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
       }
     }
   },

--- a/utils/types/index.ts
+++ b/utils/types/index.ts
@@ -1,1 +1,2 @@
 export * from './startup.type';
+export * from './playlist.type';

--- a/utils/types/playlist.type.ts
+++ b/utils/types/playlist.type.ts
@@ -1,0 +1,6 @@
+import { Playlist } from '@project/sanity/types';
+import { StartupItemType } from './startup.type';
+
+export type PlaylistCollectionsTypes = Omit<Playlist, 'selection'> & {
+  selection: StartupItemType[];
+};


### PR DESCRIPTION
- add new Sanity schema 'Playlist' (used to display Startups selection .i.e. ex: editor picks, top 10, ... of these Startups)
- generating new schema and typegen
- add Sanity typegen guides to the Readme